### PR TITLE
Get token from Authorization header

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -40,7 +40,7 @@ func main() {
 		AllowCredentials: true,
 		AllowHeaders:     []string{"Content-Type", "Authorization"},
 	}))
-	r.Use(auth.AuthHandler())
+	r.Use(auth.AuthHandler(config.JWTSecret))
 
 	r.Any("/", gin.WrapH(playground.Handler("GraphQL playground", "/query")))
 	r.POST("/query", gin.WrapH(srv))

--- a/internal/pkg/web/auth/auth.go
+++ b/internal/pkg/web/auth/auth.go
@@ -41,14 +41,14 @@ func getUserFromJWT(tokenString, secret string) (string, error) {
 	}
 }
 
-func AuthHandler() gin.HandlerFunc {
+func AuthHandler(jwtSecret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		jwt := c.GetHeader("Authorization")
 		if jwt == "" {
 			return
 		}
 
-		username, err := getUserFromJWT(jwt, "catjam")
+		username, err := getUserFromJWT(jwt, jwtSecret)
 		if err != nil {
 			c.AbortWithError(500, err)
 			return


### PR DESCRIPTION
This is part of implementing storing the token in localstorage on the frontend, because browsers block third party cookies by default nowadays